### PR TITLE
Cleanup leetcode runtime metrics from comments

### DIFF
--- a/src/prob_0001_two_sum/mod.rs
+++ b/src/prob_0001_two_sum/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 0 ms, faster than 100.00% of Rust online submissions for Two Sum.
-// Memory Usage: 2.4 MB, less than 33.11% of Rust online submissions for Two Sum.
-
 use std::collections::HashMap;
 
 #[allow(dead_code)]

--- a/src/prob_0002_add_two_nums/mod.rs
+++ b/src/prob_0002_add_two_nums/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 3 ms, faster than 88.17% of Rust online submissions for Add Two Numbers.
-// Memory Usage: 2 MB, less than 94.93% of Rust online submissions for Add Two Numbers.
-
 // Definition for singly-linked list.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct ListNode {

--- a/src/prob_0003_longest_substring/mod.rs
+++ b/src/prob_0003_longest_substring/mod.rs
@@ -2,9 +2,6 @@ use std::{char, collections::HashMap};
 
 pub struct Solution;
 
-// Runtime: 4 ms, faster than 80.02% of Rust online submissions for Longest Substring Without Repeating Characters.
-// Memory Usage: 2.2 MB, less than 42.42% of Rust online submissions for Longest Substring Without Repeating Characters.
-
 // abcabcbb
 #[allow(dead_code)]
 impl Solution {

--- a/src/prob_0007_reverse_integer/mod.rs
+++ b/src/prob_0007_reverse_integer/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 0 ms, faster than 100.00% of Rust online submissions for Reverse Integer.
-// Memory Usage: 2.1 MB, less than 67.57% of Rust online submissions for Reverse Integer.
-
 #[allow(dead_code)]
 impl Solution {
     pub fn reverse(x: i32) -> i32 {

--- a/src/prob_0008_string_to_int/mod.rs
+++ b/src/prob_0008_string_to_int/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 0 ms, faster than 100.00% of Rust online submissions for String to Integer (atoi).
-// Memory Usage: 2.1 MB, less than 28.32% of Rust online submissions for String to Integer (atoi).
-
 #[allow(dead_code)]
 impl Solution {
     pub fn my_atoi(s: String) -> i32 {

--- a/src/prob_0009_palindrome/mod.rs
+++ b/src/prob_0009_palindrome/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 4 ms, faster than 91.41% of Rust online submissions for Palindrome Number.
-// Memory Usage: 2.1 MB, less than 68.89% of Rust online submissions for Palindrome Number.
-
 #[allow(dead_code)]
 impl Solution {
     pub fn is_palindrome(x: i32) -> bool {

--- a/src/prob_0046_permutations/mod.rs
+++ b/src/prob_0046_permutations/mod.rs
@@ -1,8 +1,5 @@
 pub struct Solution;
 
-// Runtime: 3 ms, faster than 50.86% of Rust online submissions for Permutations.
-// Memory Usage: 2.2 MB, less than 61.21% of Rust online submissions for Permutations.
-
 #[allow(dead_code)]
 impl Solution {
     pub fn permute(nums: Vec<i32>) -> Vec<Vec<i32>> {


### PR DESCRIPTION
Removed the leetcode runtime comments from the top of each `mod.rs`.